### PR TITLE
Fix Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, beta, nightly, macos]
+        build: [stable, beta, nightly, macos, win-msvc, win-gnu]
         include:
           - build: stable
             os: ubuntu-latest
@@ -27,6 +27,12 @@ jobs:
           - build: macos
             os: macOS-latest
             rust: stable
+          - build: win-msvc
+            os: windows-2019
+            rust: stable
+          - build: win-gnu
+            os: windows-2019
+            rust: stable-x86_64-gnu
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,11 @@
 fn main() {
-    cmake::build("flatbuffers");
+    let mut config = cmake::Config::new("flatbuffers");
+
+    let target = std::env::var("TARGET").unwrap();
+    let host = std::env::var("HOST").unwrap();
+    if target.contains("msvc") && host.contains("windows") {
+        config.cxxflag("/EHsc");
+    }
+
+    config.build();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,11 @@
 
 /// Path of the built `flatc` executable.
 pub fn flatc() -> &'static std::path::Path {
-    std::path::Path::new(concat!(env!("OUT_DIR"), "/bin/flatc"))
+    if cfg!(windows) {
+        std::path::Path::new(concat!(env!("OUT_DIR"), "\\bin\\flatc.exe"))
+    } else {
+        std::path::Path::new(concat!(env!("OUT_DIR"), "/bin/flatc"))
+    }
 }
 
 #[test]


### PR DESCRIPTION
Hi! The two big changes that were needed is fixing the path to flatc, and MSVC needed an extra flag.

This is a successful CI run with these changes: https://github.com/JWorthe/flatc.rs/actions/runs/1011436312

I'm a bit uncertain about that extra flag. I got it from the MSVC compiler warning, which was

> warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc

That sounds reasonable, but it seems strange to me that this isn't handled by the flatbuffers CMakeLists.txt. Also, I don't see this
documented at all in the flatbuffers repo or used in their CI. I don't generally work on windows, so I don't know if this is just something that every windows dev knows.

Re #1